### PR TITLE
Configure alacritty

### DIFF
--- a/system-config/core/fonts.nix
+++ b/system-config/core/fonts.nix
@@ -1,0 +1,10 @@
+{ config, pkgs, ... }:
+
+{
+    fonts = {
+        enableDefaultFonts = true;
+        fonts = with pkgs; [
+        (nerdfonts.override { fonts = [ "FiraCode" ]; })
+        ];
+    };
+}

--- a/system-config/default.nix
+++ b/system-config/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./core/bootloader.nix
     ./core/connections.nix
+    ./core/fonts.nix
     ./core/locale.nix
     ./core/audio.nix
     ./gnome.nix

--- a/system-config/gnome.nix
+++ b/system-config/gnome.nix
@@ -4,6 +4,7 @@
   # Enable the GNOME Desktop Environment.
   services.xserver.displayManager.gdm.enable = true;
   services.xserver.desktopManager.gnome.enable = true;
+  services.xserver.displayManager.gdm.wayland = false;
 
   # Exclude GNOME packages which I don't need
   environment.gnome.excludePackages = (with pkgs; [

--- a/system-config/pkgs.nix
+++ b/system-config/pkgs.nix
@@ -12,6 +12,7 @@
     nixpkgs-fmt
     ripgrep
     shfmt
+    tealdeer
     unzip
     wget
 

--- a/user-config/default.nix
+++ b/user-config/default.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [
+    ./terminal/alacritty.nix
     ./terminal/git.nix
     ./terminal/zsh.nix
     ./terminal/starship.nix

--- a/user-config/default.nix
+++ b/user-config/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./terminal/alacritty.nix
+    ./terminal/lsd.nix
     ./terminal/git.nix
     ./terminal/zsh.nix
     ./terminal/starship.nix

--- a/user-config/terminal/alacritty.nix
+++ b/user-config/terminal/alacritty.nix
@@ -1,0 +1,15 @@
+{ lib, config, ... }:
+
+{
+    home-manager.users.brad = { pkgs, ... }: {
+        programs.alacritty = {
+            enable = true;
+            settings = {
+                font = {
+                    family = "Fira Code";
+                    size = 11;
+                };
+            };
+        };
+    };
+}

--- a/user-config/terminal/lsd.nix
+++ b/user-config/terminal/lsd.nix
@@ -1,0 +1,9 @@
+{ lib, config, ... }:
+
+{
+    home-manager.users.brad = {pkgs, ... }: {
+        programs.lsd = {
+            enable = true;
+        };
+    };
+}

--- a/user-config/terminal/zsh.nix
+++ b/user-config/terminal/zsh.nix
@@ -16,9 +16,9 @@
         c = "clear";
         clean = "nix-collect-garbage";
         cp = "cp -i";
-        ll = "ls -alFh --color=auto";
-        ls = "ls -aFh --color=auto";
-        sl = "ls -aFh --color=auto";
+        ll = "lsd -alFh --color=auto";
+        ls = "lsd -aFh --color=auto";
+        sl = "lsd -aFh --color=auto";
         mkdir = "mkdir -pv";
         mv = "mv -i";
         naon = "nano";

--- a/user-config/terminal/zsh.nix
+++ b/user-config/terminal/zsh.nix
@@ -16,9 +16,9 @@
         c = "clear";
         clean = "nix-collect-garbage";
         cp = "cp -i";
-        ll = "lsd -alFh --color=auto";
-        ls = "lsd -aFh --color=auto";
-        sl = "lsd -aFh --color=auto";
+        ll = "lsd -alFh";
+        ls = "lsd -aFh";
+        sl = "lsd -aFh";
         mkdir = "mkdir -pv";
         mv = "mv -i";
         naon = "nano";


### PR DESCRIPTION
Added new config for Alacritty.

To make this work more smoothly, I have switched the GNOME suite over to X11, rather than the default Wayland.
I have also installed a couple of extra packages to help a little, these are:

- `lsd` : To make reading of the `ls` command a bit easier
- `tealdeer` : To make the reading of man pages a bit easier