### PR TITLE
Remove unnecessary packages from GNOME launcher

### DIFF
--- a/system-config/gnome.nix
+++ b/system-config/gnome.nix
@@ -22,13 +22,20 @@
     gnome-characters
     gnome-clocks
     gnome-contacts
+    gnome-font-viewer
+    gnome-logs
     gnome-maps
     gnome-music
     gnome-system-monitor
+    pkgs.gnome-text-editor
     gnome-weather
     hitori # sudoku game
     iagno # go game
+    pkgs.gnome-connections
+    seahorse # password manager
     simple-scan
     tali # poker game
+    vinagre
+    yelp
   ]);
 }

--- a/user-config/default.nix
+++ b/user-config/default.nix
@@ -12,6 +12,7 @@
     ./terminal/bat.nix
     ./terminal/direnv.nix
     ./terminal/git.nix
+    ./terminal/htop.nix
     ./terminal/lsd.nix
     ./terminal/helix.nix
     ./terminal/starship.nix

--- a/user-config/display/dconf.nix
+++ b/user-config/display/dconf.nix
@@ -43,7 +43,7 @@ with lib.hm.gvariant;
     };
 
     "org/gnome/desktop/app-folders/folders/Utilities" = {
-      apps = [ "gnome-abrt.desktop" "gnome-system-log.desktop" "nm-connection-editor.desktop" "org.gnome.baobab.desktop" "org.gnome.Connections.desktop" "org.gnome.DejaDup.desktop" "org.gnome.Dictionary.desktop" "org.gnome.DiskUtility.desktop" "org.gnome.eog.desktop" "org.gnome.Evince.desktop" "org.gnome.FileRoller.desktop" "org.gnome.fonts.desktop" "org.gnome.seahorse.Application.desktop" "org.gnome.tweaks.desktop" "org.gnome.Usage.desktop" "vinagre.desktop" "org.gnome.Totem.desktop" "yelp.desktop" "org.gnome.Extensions.desktop" "htop.desktop" "org.gnome.TextEditor.desktop" "org.gnome.Tour.desktop" "xterm.desktop" "nvim.desktop" ];
+      apps = [ "gnome-abrt.desktop" "nm-connection-editor.desktop" "org.gnome.Dictionary.desktop" "org.gnome.DiskUtility.desktop" "org.gnome.eog.desktop" "org.gnome.Evince.desktop" "org.gnome.FileRoller.desktop" "org.gnome.tweaks.desktop" "org.gnome.Usage.desktop" "org.gnome.Totem.desktop" "org.gnome.Extensions.desktop" "xterm.desktop"];
       categories = [ "X-GNOME-Utilities" ];
       name = "X-GNOME-Utilities.directory";
       translate = true;

--- a/user-config/personal-packages.nix
+++ b/user-config/personal-packages.nix
@@ -5,7 +5,6 @@
     pkgs.calibre
     pkgs.fd
     pkgs.firefox
-    pkgs.htop
     pkgs.libreoffice
     pkgs.neofetch
     pkgs.nixpkgs-fmt

--- a/user-config/terminal/helix.nix
+++ b/user-config/terminal/helix.nix
@@ -8,5 +8,10 @@ _:
         theme="base16_default_dark";
       };
     };
+    xdg.desktopEntries.Helix = {
+      name = "Helix";
+      exec = "hx";
+      noDisplay = true;
+    };
   };
 }

--- a/user-config/terminal/helix.nix
+++ b/user-config/terminal/helix.nix
@@ -5,7 +5,7 @@ _:
     programs.helix = {
       enable = true;
       settings = {
-        theme="base16_default_dark";
+        theme = "base16_default_dark";
       };
     };
     xdg.desktopEntries.Helix = {

--- a/user-config/terminal/htop.nix
+++ b/user-config/terminal/htop.nix
@@ -1,0 +1,15 @@
+_:
+
+{
+  home-manager.users.brad = { pkgs, ...}: {
+    programs.htop = {
+      enable = true;
+    };
+
+    xdg.desktopEntries.htop = {
+      name = "Htop";
+      exec = "htop";
+      noDisplay = true;
+    };
+  };
+}

--- a/user-config/terminal/htop.nix
+++ b/user-config/terminal/htop.nix
@@ -1,7 +1,7 @@
 _:
 
 {
-  home-manager.users.brad = { pkgs, ...}: {
+  home-manager.users.brad = { pkgs, ... }: {
     programs.htop = {
       enable = true;
     };


### PR DESCRIPTION
I have been looking for a way to do this for ages. The program still exists but the icon in the launcher is now removed. I always invoke it in the terminal ;)